### PR TITLE
Add Pubsub Adapter and Client

### DIFF
--- a/app/jobs/hello_kisi_job.rb
+++ b/app/jobs/hello_kisi_job.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class HelloKisiJob < ActiveJob::Base
+  queue_as(:default)
+  retry_on(StandardError, wait: 5.minutes, attempts: 2)
+
+  def perform(*_args)
+    puts("Hello Kisi")
+  end
+end

--- a/app/jobs/new_job.rb
+++ b/app/jobs/new_job.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class NewJob < ActiveJob::Base
+  queue_as(:default)
+  retry_on(StandardError, wait: 5.minutes, attempts: 2)
+
+  def perform(*_args)
+    puts("New Job")
+  end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -24,6 +24,9 @@ Bundler.require(*Rails.groups)
 require_relative("../lib/active_job/queue_adapters/pubsub_adapter")
 require_relative("../lib/pubsub")
 
+TOPIC = "kisi-challenge-topic"
+SUBSCRIPTION = "kisi-challenge-topic-sub"
+
 module KisiApiChallenge
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
@@ -44,5 +47,8 @@ module KisiApiChallenge
 
     # Configures the custom queue adapter.
     config.active_job.queue_adapter = :pubsub
+
+    google_pubsub = Pubsub.new(TOPIC, SUBSCRIPTION)
+    config.pubsub_client = google_pubsub
   end
 end

--- a/lib/active_job/queue_adapters/pubsub_adapter.rb
+++ b/lib/active_job/queue_adapters/pubsub_adapter.rb
@@ -3,11 +3,15 @@
 module ActiveJob
   module QueueAdapters
     class PubsubAdapter
+      attr_writer(:enqueued_jobs)
+
       # Enqueue a job to be performed.
       #
       # @param [ActiveJob::Base] job The job to be performed.
       def enqueue(job)
-        raise(NotImplementedError)
+        puts("Enqueing job #{job.inspect}")
+        job_data = job_to_hash(job)
+        perform(job, job_data)
       end
 
       # Enqueue a job to be performed at a certain time.
@@ -15,7 +19,33 @@ module ActiveJob
       # @param [ActiveJob::Base] job The job to be performed.
       # @param [Float] timestamp The time to perform the job.
       def enqueue_at(job, timestamp)
-        raise(NotImplementedError)
+        delay = timestamp - Time.current.to_f
+        t1 = Thread.new do
+          sleep(delay)
+          enqueue(job)
+        end
+        t1.join
+      end
+
+      def enqueued_jobs
+        @enqueued_jobs ||= []
+      end
+
+      private
+
+      def job_to_hash(job, extras = {})
+        job.serialize.tap do |job_data|
+          job_data[:job] = job.class
+          job_data[:args] = job_data.fetch("arguments")
+          job_data[:queue] = job_data.fetch("queue_name")
+          job_data[:priority] = job_data.fetch("priority")
+        end.merge(extras)
+      end
+
+      def perform(job, job_data)
+        enqueued_jobs << job_data
+        payload = job.class.to_s
+        Rails.application.config.pubsub_client.publish(payload)
       end
     end
   end

--- a/lib/pubsub.rb
+++ b/lib/pubsub.rb
@@ -3,12 +3,61 @@
 require("google/cloud/pubsub")
 
 class Pubsub
+  # Initialize PubSub
+  #
+  # @param topic [String] The name of the topic to find or create
+  # @param subscription [String] The name of the subscription to find or create
+  # @return [PubSub]
+  def initialize(topic, subscription)
+    @topic = topic(topic)
+    @subscription = subscription
+  end
+
   # Find or create a topic.
   #
   # @param topic [String] The name of the topic to find or create
   # @return [Google::Cloud::PubSub::Topic]
   def topic(name)
     client.topic(name) || client.create_topic(name)
+  end
+
+  # Find or create a subscription on the topic
+  # @return [Google::Cloud::PubSub::Subscription]
+  def subscription
+    @topic.subscription(@subscription) || @topic.subscribe(@subscription)
+  end
+
+  # Publish message to pubsub
+  # @param message [String] The message payload
+  # @return [Google::Cloud::PubSub::Message]
+  def publish(message)
+    @topic.publish(message)
+  end
+
+  # Pulls messages from subscription and executes relevant job
+  # More info: https://googleapis.dev/ruby/google-cloud-pubsub/latest/index.html#receiving-messages
+  def start_listening
+    sub = subscription
+    subscriber = sub.listen(threads: { callback: 16 }) do |received_message|
+      # process message
+      puts("Data: #{received_message.message.data}, published at #{received_message.message.published_at}")
+      received_message.acknowledge!
+      execute_job(received_message.message.data)
+    end
+
+    # Handle exceptions from listener
+    subscriber.on_error do |exception|
+      puts("Exception: #{exception.class} #{exception.message}")
+    end
+
+    # Gracefully shut down the subscriber on program exit, blocking until
+    # all received messages have been processed or 10 seconds have passed
+    at_exit do
+      subscriber.stop!(10)
+    end
+
+    # Start background threads that will call the block passed to listen.
+    subscriber.start
   end
 
   private
@@ -18,5 +67,12 @@ class Pubsub
   # @return [Google::Cloud::PubSub]
   def client
     @client ||= Google::Cloud::PubSub.new(project_id: "code-challenge")
+  end
+
+  # Execute relevant job
+  def execute_job(job)
+    job.constantize.send(:perform_now)
+  rescue StandardError => e
+    puts("Couldn't enqueue job", e)
   end
 end

--- a/test/active_job /queue_adapters/pubsub_adapter_test.rb
+++ b/test/active_job /queue_adapters/pubsub_adapter_test.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require("test_helper")
+
+class PubsubAdapterTest < Minitest::Test
+  def setup
+    @job = HelloKisiJob.new
+    @adapter = ActiveJob::Base.queue_adapter
+    @client = Minitest::Mock.new
+    @adapter.enqueued_jobs = []
+    Rails.application.config.pubsub_client = @client
+    @client.expect(:publish, true, [@job.class.to_s])
+  end
+
+  def test_that_enqueues_job
+    assert_equal(0, @adapter.enqueued_jobs.length)
+    @adapter.enqueue(@job)
+    assert_equal(1, @adapter.enqueued_jobs.length)
+    @client.verify
+  end
+
+  def test_enqueued_at
+    assert_equal(0, @adapter.enqueued_jobs.length)
+    @adapter.enqueue_at(@job, Time.current.to_f + 0.5)
+    assert_equal(1, @adapter.enqueued_jobs.length)
+    @client.verify
+  end
+end

--- a/test/jobs/hello_kisi_job_test.rb
+++ b/test/jobs/hello_kisi_job_test.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require("test_helper")
+
+class HelloKisiJobTest < ActiveJob::TestCase
+  setup do
+    @client = Minitest::Mock.new
+    Rails.application.config.pubsub_client = @client
+    @client.expect(:publish, true, [String])
+  end
+
+  test("that job is enqueued") do
+    assert_enqueued_jobs(0)
+    HelloKisiJob.perform_later
+    assert_enqueued_jobs(1)
+  end
+
+  test("that job is using correct queue adapter") do
+    assert_instance_of(ActiveJob::QueueAdapters::PubsubAdapter, HelloKisiJob.queue_adapter)
+  end
+end

--- a/test/pubsub_test.rb
+++ b/test/pubsub_test.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require("test_helper")
+
+class PubsubTest < Minitest::Test
+  def setup
+    @client = Pubsub.new("test-topic", "test-topic-sub")
+  end
+
+  def test_that_creates_topic
+    new_topic = @client.topic("new-topic")
+    assert_instance_of(Google::Cloud::PubSub::Topic, new_topic)
+  end
+
+  def test_that_finds_topic
+    old_topic = @client.topic("test-topic")
+    assert_instance_of(Google::Cloud::PubSub::Topic, old_topic)
+  end
+
+  def test_that_creates_subscription
+    subscription = @client.subscription
+    assert_instance_of(Google::Cloud::PubSub::Subscription, subscription)
+  end
+
+  def test_that_publishes_message
+    topic = @client.topic("new-topic")
+    message = topic.publish("new message")
+    assert_instance_of(Google::Cloud::PubSub::Message, message)
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,8 +1,11 @@
 # frozen_string_literal: true
 
 ENV["RAILS_ENV"] ||= "test"
+ENV["PUBSUB_EMULATOR_HOST"] = "localhost:8681"
+
 require_relative("../config/environment")
 require("rails/test_help")
+require("minitest/autorun")
 
 module ActiveSupport
   class TestCase
@@ -10,5 +13,10 @@ module ActiveSupport
     parallelize(workers: :number_of_processors)
 
     # Add more helper methods to be used by all tests here...
+
+    def setup
+      (ActiveJob::Base.descendants << ActiveJob::Base).each(&:disable_test_adapter)
+      ActiveJob::Base.queue_adapter = ActiveJob::QueueAdapters::PubsubAdapter.new
+    end
   end
 end


### PR DESCRIPTION
This commit adds custom Pubsub Adapter and registers it in `application.rb` as default adapter.

Google PubSub client for publishing and subscribing is added in `pubsub.rb`. The client uses pubsub emulator:
https://github.com/googleapis/google-cloud-ruby/blob/main/google-cloud-pubsub/EMULATOR.md

For testing, 2 jobs are created in `/jobs/` directory